### PR TITLE
Add basic data cache support

### DIFF
--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -4,14 +4,11 @@ from numpy.testing import assert_array_equal
 from forecastingGDP.data import CACHE_LOCATION, SERIES_ID, clear_cache, get_data
 
 def test_get_data():
-    data = get_data()
-    assert len(data) > 0
-    assert data.shape[1] == len(SERIES_ID)
-
-def test_get_data_cached():
-    data = get_data()
+    data = get_data(use_cache=True)
     data_cached = get_data(use_cache=True)
     assert isfile(CACHE_LOCATION)
+    assert len(data) > 0
+    assert data.shape[1] == len(SERIES_ID)
     assert data.shape == data_cached.shape
     assert data.index.dtype == data_cached.index.dtype
     assert_array_equal(data.dtypes, data_cached.dtypes)

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -1,8 +1,24 @@
+from os.path import isfile
 from numpy.testing import assert_array_equal
 
-from forecastingGDP.data import SERIES_ID, get_data
+from forecastingGDP.data import CACHE_LOCATION, SERIES_ID, clear_cache, get_data
 
 def test_get_data():
     data = get_data()
     assert len(data) > 0
     assert data.shape[1] == len(SERIES_ID)
+
+def test_get_data_cached():
+    data = get_data()
+    data_cached = get_data(use_cache=True)
+    assert isfile(CACHE_LOCATION)
+    assert data.shape == data_cached.shape
+    assert data.index.dtype == data_cached.index.dtype
+    assert_array_equal(data.dtypes, data_cached.dtypes)
+
+def test_clear_cache():
+    if not isfile(CACHE_LOCATION):
+        get_data(use_cache=True)
+    assert isfile(CACHE_LOCATION)
+    clear_cache()
+    assert not isfile(CACHE_LOCATION)


### PR DESCRIPTION
Usage:
```python
from forecastingGDP.data import get_data, clear_cache

data = get_data(use_cache=True) # default is False
# to get rid of cached data
clear_cache()
```

Cache is located at `~/.forecastingGDP.cache.csv`.
