### PR TITLE
Add series first release values

### DIFF
--- a/forecastingGDP/data.py
+++ b/forecastingGDP/data.py
@@ -53,13 +53,14 @@ SERIES = {
 
 SERIES_ID = list(SERIES.values())
 
-FREQUENCY = 'q'
 AGGREGATION_METHOD = 'avg'
-REALTIME_START='1940-01-01'
+FREQUENCY = 'q'
+OBSERVATION_START='1947-01-01'
+OUTPUT_TYPE_FIRST_RELEASE = 4
+OUTPUT_TYPE_NEW_AND_REVISED = 3
 OUTPUT_TYPE_REALTIME = 1
 OUTPUT_TYPE_VINTAGE_ALL = 2
-OUTPUT_TYPE_NEW_AND_REVISED = 3
-OUTPUT_TYPE_FIRST_RELEASE = 4
+REALTIME_START='1940-01-01'
 
 CACHE_LOCATION = os.path.expanduser('~/.forecastingGDP.cache.csv')
 
@@ -86,6 +87,7 @@ def __load_series(series_id):
     return FRED.get_series(
         series_id,
         frequency=FREQUENCY,
+        observation_start=OBSERVATION_START,
         aggregation_method=AGGREGATION_METHOD,
         output_type=OUTPUT_TYPE_REALTIME,
     )
@@ -102,6 +104,7 @@ def __load_series_first_release(series_id):
         # using `mean`.
         return FRED.get_series(
             series_id,
+            observation_start=OBSERVATION_START,
             realtime_start=REALTIME_START,
             output_type=OUTPUT_TYPE_FIRST_RELEASE,
         ).resample('QS-Jan').mean()

--- a/forecastingGDP/data.py
+++ b/forecastingGDP/data.py
@@ -54,6 +54,12 @@ SERIES = {
 SERIES_ID = list(SERIES.values())
 
 FREQUENCY = 'q'
+AGGREGATION_METHOD = 'avg'
+REALTIME_START='1940-01-01'
+OUTPUT_TYPE_REALTIME = 1
+OUTPUT_TYPE_VINTAGE_ALL = 2
+OUTPUT_TYPE_NEW_AND_REVISED = 3
+OUTPUT_TYPE_FIRST_RELEASE = 4
 
 CACHE_LOCATION = os.path.expanduser('~/.forecastingGDP.cache.csv')
 
@@ -67,8 +73,40 @@ def __load_data():
     '''returns data from FRED API'''
     data = {}
     for series_id in SERIES_ID:
-        data[series_id] = FRED.get_series(series_id, frequency=FREQUENCY)
+        series = __load_series(series_id)
+        series_first_release = __load_series_first_release(series_id)
+        if series_first_release is None: # SP500 does not have first release information
+            series_first_release = series
+        data[series_id] = series
+        data[series_id+'_first_release'] = series_first_release
     return pd.DataFrame(data)
+
+def __load_series(series_id):
+    '''returns the series of ID `series_id` with a quarter frequency'''
+    return FRED.get_series(
+        series_id,
+        frequency=FREQUENCY,
+        aggregation_method=AGGREGATION_METHOD,
+        output_type=OUTPUT_TYPE_REALTIME,
+    )
+
+def __load_series_first_release(series_id):
+    '''returns the series of ID `series_id` with a quarter frequency
+    at the time it was first released, or None if such information is
+    not available'''
+
+    assert AGGREGATION_METHOD == 'avg'
+    try:
+        # NOTE: frequency cannot be used when requesting first release
+        # (output_type=4), data must be aggregated by quarter manually
+        # using `mean`.
+        return FRED.get_series(
+            series_id,
+            realtime_start=REALTIME_START,
+            output_type=OUTPUT_TYPE_FIRST_RELEASE,
+        ).resample('QS-Jan').mean()
+    except ValueError:
+        return None
 
 def __load_cache():
     '''returns data cached locally at `CACHE_LOCATION` otherwise cache it from FRED API'''

--- a/forecastingGDP/data.py
+++ b/forecastingGDP/data.py
@@ -126,3 +126,9 @@ def clear_cache():
         os.remove(CACHE_LOCATION)
     except FileNotFoundError:
         pass
+
+def first_release_selector(data):
+    return data.columns.str.endswith('_first_release')
+
+def without_first_release(data):
+    return data.loc[:, ~first_release_selector(data)]

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -8,7 +8,7 @@ def test_get_data():
     data_cached = get_data(use_cache=True)
     assert isfile(CACHE_LOCATION)
     assert len(data) > 0
-    assert data.shape[1] == len(SERIES_ID)
+    assert data.shape[1] == len(SERIES_ID)*2
     assert data.shape == data_cached.shape
     assert data.index.dtype == data_cached.index.dtype
     assert_array_equal(data.dtypes, data_cached.dtypes)


### PR DESCRIPTION
`get_data()` now also returns series first release value.

ex: 'INDPRO' column contains industrial production, 'INDPRO_first_release' contains the initial released value of INDPRO.

Keep in mind that first release value **may not be available although fixed value is**, ie you could have a `NaN` although revised value is not `NaN`.
