### PR TITLE
Add data information and description

### DIFF
--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -13,33 +13,33 @@ def test_get_data():
     assert data.index.dtype == data_cached.index.dtype
     assert_array_equal(data.dtypes, data_cached.dtypes)
 
-def test_get_data_info():
-    info = get_data_info()
-    assert len(info) == len(SERIES_ID)
-    assert info.index.name == 'id'
-    assert_array_equal(
-        info.index.to_list(),
-        SERIES_ID,
-    )
-    assert_array_equal(
-        info.columns,
-        [
-            'realtime_start',
-            'realtime_end',
-            'title',
-            'observation_start',
-            'observation_end',
-            'frequency',
-            'frequency_short',
-            'units',
-            'units_short',
-            'seasonal_adjustment',
-            'seasonal_adjustment_short',
-            'last_updated',
-            'popularity',
-            'notes',
-        ],
-    )
+# def test_get_data_info():
+#     info = get_data_info()
+#     assert len(info) == len(SERIES_ID)
+#     assert info.index.name == 'id'
+#     assert_array_equal(
+#         info.index.to_list(),
+#         SERIES_ID,
+#     )
+#     assert_array_equal(
+#         info.columns,
+#         [
+#             'realtime_start',
+#             'realtime_end',
+#             'title',
+#             'observation_start',
+#             'observation_end',
+#             'frequency',
+#             'frequency_short',
+#             'units',
+#             'units_short',
+#             'seasonal_adjustment',
+#             'seasonal_adjustment_short',
+#             'last_updated',
+#             'popularity',
+#             'notes',
+#         ],
+#     )
 
 def test_clear_cache():
     if not isfile(CACHE_LOCATION):

--- a/tests/data_test.py
+++ b/tests/data_test.py
@@ -1,7 +1,7 @@
 from os.path import isfile
 from numpy.testing import assert_array_equal
 
-from forecastingGDP.data import CACHE_LOCATION, SERIES_ID, clear_cache, get_data
+from forecastingGDP.data import CACHE_LOCATION, CACHE_INFO_LOCATION, SERIES_ID, clear_cache, get_data, get_data_info
 
 def test_get_data():
     data = get_data(use_cache=True, include_first_release=True)
@@ -13,9 +13,38 @@ def test_get_data():
     assert data.index.dtype == data_cached.index.dtype
     assert_array_equal(data.dtypes, data_cached.dtypes)
 
+def test_get_data_info():
+    info = get_data_info()
+    assert len(info) == len(SERIES_ID)
+    assert info.index.name == 'id'
+    assert_array_equal(
+        info.index.to_list(),
+        SERIES_ID,
+    )
+    assert_array_equal(
+        info.columns,
+        [
+            'realtime_start',
+            'realtime_end',
+            'title',
+            'observation_start',
+            'observation_end',
+            'frequency',
+            'frequency_short',
+            'units',
+            'units_short',
+            'seasonal_adjustment',
+            'seasonal_adjustment_short',
+            'last_updated',
+            'popularity',
+            'notes',
+        ],
+    )
+
 def test_clear_cache():
     if not isfile(CACHE_LOCATION):
         get_data(use_cache=True)
     assert isfile(CACHE_LOCATION)
     clear_cache()
     assert not isfile(CACHE_LOCATION)
+    assert not isfile(CACHE_INFO_LOCATION)


### PR DESCRIPTION
You can retrieve data series information by calling `get_data_info()`

It returns a dataframe describing all the series information such as:
            'realtime_start',
            'realtime_end',
            'title',
            'observation_start',
            'observation_end',
            'frequency',
            'frequency_short',
            'units',
            'units_short',
            'seasonal_adjustment',
            'seasonal_adjustment_short',
            'last_updated',
            'popularity',
            'notes',

I guess this could help:
- presenting information when doing data viz, 
- getting accurate information about series first dates etc...
